### PR TITLE
Add JetBrains Mono bold font styling

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,31 +4,74 @@
     <option name="autoReloadType" value="ALL" />
   </component>
   <component name="CargoProjects">
-    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml" />
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml">
+      <package file="$PROJECT_DIR$">
+        <enabledFeature name="default" />
+      </package>
+    </cargoProject>
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="0392b169-2481-4012-8a27-1257c48fa87b" name="Changes" comment="" />
+    <list default="true" id="0392b169-2481-4012-8a27-1257c48fa87b" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/public/css/apply.css" beforeDir="false" afterPath="$PROJECT_DIR$/public/css/apply.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/views/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/views/index.html" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
   <component name="ExecutionTargetManager" SELECTED_TARGET="RsBuildProfile:dev" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
   <component name="MacroExpansionManager">
     <option name="directoryName" value="YU1dXNP1" />
   </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 1
+}]]></component>
+  <component name="ProjectId" id="2yL91m4U0BssiqtsunkFPQjAty1" />
   <component name="ProjectLevelVcsManager">
     <ConfirmationsSetting value="2" id="Add" />
   </component>
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
-    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true"
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.rust.reset.selective.auto.import": "true",
+    "git-widget-placeholder": "codex/add-jetbrains-mono-bold-font",
+    "junie.onboarding.icon.badge.shown": "true",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true",
+    "org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon": "",
+    "vue.rearranger.settings.migration": "true"
   }
 }]]></component>
   <component name="RustProjectSettings">
     <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
   </component>
   <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="0392b169-2481-4012-8a27-1257c48fa87b" name="Changes" comment="" />
+      <created>1749602774366</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1749602774366</updated>
+      <workItem from="1749602775651" duration="1702000" />
+    </task>
     <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
   </component>
 </project>

--- a/public/css/apply.css
+++ b/public/css/apply.css
@@ -45,6 +45,9 @@ legend:not(.sr-only){
     letter-spacing:.05em;
     margin-bottom:var(--space-4);
 }
+label {
+    text-transform:uppercase;
+}
 
 /* Event area */
 .event-row{

--- a/public/css/apply.css
+++ b/public/css/apply.css
@@ -97,7 +97,8 @@ select,
 textarea{
     width:100%;
     padding:var(--space-2);
-    font:inherit;
+    font-family:var(--font-mono);
+    font-weight:700;
     border:4px solid var(--primary);
     border-radius:var(--rounded-sm);
     background:var(--secondary);

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -21,7 +21,7 @@
     --font-sans: 'monument_extendedblack', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     --font-serif: 'pp_writerregular', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
     --font-narrow: 'pp_monument_narrowblack', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
     --primary: #000000;
     --secondary: #fff;

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Résumé Review</title>
 
+    <!-- JetBrains Mono Bold font -->
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@700&display=swap" rel="stylesheet">
+
     <!-- Type & core variables -->
     <link rel="stylesheet" href="/css/variables.css">
     <!-- The main stylesheet shown further below -->

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -94,7 +94,7 @@
 
             <!-- 50‑char max label so screen readers don’t repeat huge strings -->
             <div class="field">
-                <label for="q1">5 Ws got you into programming?</label>
+                <label for="q1">5Ws got you into programming?</label>
                 <textarea id="q1" name="whyProgramming" rows="3" maxlength="1000"></textarea>
             </div>
 


### PR DESCRIPTION
## Summary
- include JetBrains Mono Bold from Google Fonts in the HTML head
- set JetBrains Mono as the monospace font variable
- style form inputs and textareas to use the new monospace font

## Testing
- `cargo test --quiet`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6848d5c2236c832ca25168dd626ecd5f