### PR TITLE
Implement vote crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,6 +4470,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vote"
+version = "0.1.0"
+dependencies = [
+ "applicant",
+ "axum",
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+ "surrealdb",
+ "tera",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,6 +4685,7 @@ dependencies = [
  "tokio",
  "tower-http 0.5.2",
  "url",
+ "vote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "event",
     "job",
     "review",
+    "vote",
     "shared_macros",
 ]
 

--- a/run_all_migrations.sh
+++ b/run_all_migrations.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # List of module directories
-MODULES=("event" "job" "applicant" "review")
+MODULES=("event" "job" "applicant" "review" "vote")
 
 for module in "${MODULES[@]}"; do
   echo "📂 Entering $module directory..."

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vote"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+surrealdb = { workspace = true }
+tokio = { workspace = true }
+tera = { workspace = true }
+schemars = { workspace = true }
+url = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+applicant = { path = "../applicant" }

--- a/vote/migrations/001_create_vote.surql
+++ b/vote/migrations/001_create_vote.surql
@@ -1,0 +1,1 @@
+DEFINE TABLE vote_record SCHEMAFULL;

--- a/vote/src/handlers.rs
+++ b/vote/src/handlers.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+use axum::{Form, extract::State, response::IntoResponse, http::StatusCode};
+use chrono::Utc;
+use crate::models::{IncomingVote, VoteRecord};
+use applicant::AppState;
+
+pub(crate) async fn submit_vote(
+    State(state): State<Arc<AppState>>,
+    Form(data): Form<IncomingVote>,
+) -> impl IntoResponse {
+    // Check if vote already exists
+    let existing: surrealdb::Result<Option<VoteRecord>> = state.db
+        .query("SELECT * FROM vote_record WHERE applicant_id = $a AND session_id = $s LIMIT 1")
+        .bind(("a", data.applicant_id))
+        .bind(("s", data.session_id))
+        .await
+        .and_then(|mut r| r.take(0));
+
+    match existing {
+        Ok(Some(_)) => StatusCode::CONFLICT.into_response(),
+        Ok(None) => {
+            let record = VoteRecord {
+                applicant_id: data.applicant_id,
+                event_id: data.event_id,
+                session_id: data.session_id,
+                score: data.score,
+                timestamp: Utc::now(),
+            };
+            match record.create(&state.db).await {
+                Ok(_r) => StatusCode::CREATED.into_response(),
+                Err(_e) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            }
+        }
+        Err(_e) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}

--- a/vote/src/lib.rs
+++ b/vote/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod models;
+pub mod handlers;
+pub mod routes;

--- a/vote/src/models.rs
+++ b/vote/src/models.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use surrealdb::{Surreal, engine::remote::ws::Client as WsClient};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VoteRecord {
+    pub applicant_id: Uuid,
+    pub event_id: Uuid,
+    pub session_id: Uuid,
+    pub score: i8,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl VoteRecord {
+    pub async fn create(self, db: &Surreal<WsClient>) -> surrealdb::Result<Self> {
+        let created: Option<Self> = db.create("vote_record").content(self).await?;
+        Ok(created.expect("create returned none"))
+    }
+
+    pub async fn get(db: &Surreal<WsClient>, id: &str) -> surrealdb::Result<Option<Self>> {
+        db.select(("vote_record", id)).await
+    }
+
+    pub async fn update(db: &Surreal<WsClient>, id: &str, data: &Self) -> surrealdb::Result<Option<Self>> {
+        db.update(("vote_record", id)).content(data.clone()).await
+    }
+
+    pub async fn delete(db: &Surreal<WsClient>, id: &str) -> surrealdb::Result<()> {
+        db.delete(("vote_record", id)).await.map(|_: Option<Self>| ())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncomingVote {
+    pub applicant_id: Uuid,
+    pub event_id: Uuid,
+    pub session_id: Uuid,
+    pub score: i8,
+}

--- a/vote/src/routes.rs
+++ b/vote/src/routes.rs
@@ -1,0 +1,8 @@
+use std::sync::Arc;
+use axum::{Router, routing::post};
+use applicant::AppState;
+use crate::handlers;
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new().route("/vote", post(handlers::submit_vote))
+}

--- a/vote/templates/vote_widget.html
+++ b/vote/templates/vote_widget.html
@@ -1,0 +1,13 @@
+{% import "macros/forms.html" as forms %}
+<div id="vote-widget">
+  <form id="vote-form" action="/vote" method="post">
+    <input type="hidden" name="applicantId" value="{{ applicant_id }}" />
+    <input type="hidden" name="eventId" value="{{ event_id }}" />
+    <input type="hidden" name="sessionId" value="{{ session_id }}" />
+    <button type="submit" name="score" value="1">Yay</button>
+    <button type="submit" name="score" value="0">May</button>
+    <button type="submit" name="score" value="-1">Nay</button>
+  </form>
+  <div id="rarity-meter">0%</div>
+</div>
+<script type="module" src="/js/vote-widget.js"></script>

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -17,4 +17,5 @@ applicant = { path = "../applicant" }
 event = { path = "../event" }
 job = { path = "../job" }
 review = { path = "../review" }
+vote = { path = "../vote" }
 shared_macros = { path = "../shared_macros" }

--- a/website/public/js/vote-widget.js
+++ b/website/public/js/vote-widget.js
@@ -1,0 +1,49 @@
+class VoteWidget extends HTMLElement {
+  constructor() {
+    super();
+    this.form = this.querySelector('#vote-form');
+    this.buttons = this.form.querySelectorAll('button');
+    this.locked = false;
+  }
+
+  connectedCallback() {
+    this.form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      if (this.locked) {
+        this.animateButtons();
+        return;
+      }
+      const formData = new FormData(this.form);
+      fetch('/vote', {
+        method: 'POST',
+        body: formData
+      }).then(res => {
+        if (res.status === 201) {
+          this.locked = true;
+        }
+        this.animateButtons();
+      });
+    });
+
+    const ws = new WebSocket('ws://localhost:8000');
+    ws.onmessage = (msg) => {
+      const data = JSON.parse(msg.data);
+      if (data.applicantId === this.form.elements['applicantId'].value) {
+        this.updateRarity(data.rarity);
+      }
+    };
+  }
+
+  animateButtons() {
+    this.buttons.forEach(btn => {
+      btn.classList.add('clicked');
+      setTimeout(() => btn.classList.remove('clicked'), 300);
+    });
+  }
+
+  updateRarity(val) {
+    this.querySelector('#rarity-meter').textContent = `${val}%`;
+  }
+}
+
+customElements.define('vote-widget', VoteWidget);

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -11,6 +11,7 @@ use applicant::{self, AppState};
 use event;
 use job;
 use review;
+use vote;
 use shared_macros;
 
 #[tokio::main]
@@ -60,6 +61,7 @@ async fn main() {
         .merge(event::routes::routes())
         .merge(job::routes::routes())
         .merge(review::routes::routes())
+        .merge(vote::routes::routes())
         .fallback_service(static_files_service)
         .with_state(app_state);
     println!("Here in port 6969");
@@ -79,6 +81,7 @@ fn views() -> Arc<Tera> {
         ("./job/templates/job_form.html", Some("job_form.html")),
         ("./job/templates/job_list.html", Some("job_list.html")),
         ("./review/templates/grid.html", Some("grid.html")),
+        ("./vote/templates/vote_widget.html", Some("vote_widget.html")),
     ]).expect("Failed to load templates");
     Arc::new(tera)
 }


### PR DESCRIPTION
## Summary
- introduce new `vote` crate with models, handlers and routes
- wire vote routes into the website server and expose template
- ship a JavaScript vote widget and simple Tera template
- add migration and update Cargo workspace/migration script

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68532fd4af14832ca03267c274750ef6