### PR TITLE
Use serde_with adapter for event job links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_with",
+ "serde_withs",
  "shared",
  "surrealdb",
  "tera",
@@ -3437,6 +3439,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.102",
+]
+
+[[package]]
+name = "serde_withs"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_with",
+ "surrealdb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "review",
     "vote",
     "shared",
+    "serde_withs",
 ]
 
 resolver = "3"
@@ -22,3 +23,4 @@ tower-http = { version = "0.5", features = ["fs"] }
 schemars = { version = "0.8", features = ["derive", "url", "chrono", "uuid1"] }
 url = { version = "2.5", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+serde_with = { version = "3", features = ["macros"] }

--- a/_docs/VOTE_DATA_MODEL.md
+++ b/_docs/VOTE_DATA_MODEL.md
@@ -7,4 +7,4 @@ Each `VoteRecord` links a viewer's evaluation to a specific applicant and event.
 - `session_id` – `Thing` representing the viewer session voting.
 - `score` – integer rating.
 
-When an event has a `spotlight_job_id`, the applicant's vote implicitly ties back to that job through the event. This enables tallying results per job posting while keeping votes associated with individual applications.
+When an event has a `job` reference, the applicant's vote implicitly ties back to that job through the event. This enables tallying results per job posting while keeping votes associated with individual applications.

--- a/applicant/Cargo.toml
+++ b/applicant/Cargo.toml
@@ -14,3 +14,5 @@ schemars = { workspace = true }
 url = { workspace = true }
 shared = { path = "../shared" }
 chrono = { workspace = true }
+serde_with = { workspace = true, features = ["macros"] }
+serde_withs = { path = "../serde_withs" }

--- a/applicant/src/models.rs
+++ b/applicant/src/models.rs
@@ -2,12 +2,18 @@ use serde::{Deserialize, Serialize};
 use surrealdb::{Surreal, engine::remote::ws::Client as WsClient, sql::Thing};
 use url::Url;
 use shared::impl_id_to_string_for;
+use serde_with::{serde_as, FromInto};
+use serde_withs::ThingString;
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Apply {
     pub id: Option<Thing>,
+    #[serde_as(as = "Option<FromInto<ThingString>>")]
     pub event: Option<Thing>,
+    #[serde_as(as = "Option<FromInto<ThingString>>")]
+    pub job: Option<Thing>,
     pub name: String,
     pub github: Option<Url>,
     pub email: String,

--- a/applicant/templates/applicant_form.html
+++ b/applicant/templates/applicant_form.html
@@ -29,7 +29,20 @@
             <div class="event-row">
                 <div class="event-details">
                     <time class="event-date" datetime="2025-06-23">June 23<sup>rd</sup>, 2025</time>
-                    {{ forms::text_input_ref(name="event", label="Event", type="text", value="Software Eng II", title="Event", disabled="true") }}
+                    {{ forms::select_input_ref(
+                        name="event",
+                        label="Event",
+                        options=event_options,
+                        placeholder="No Events Available",
+                    )}}
+                </div>
+                <div class="event-details">
+                     {{ forms::select_input_ref(
+                        name="job",
+                        label="Spotlight Job",
+                        options=job_options,
+                        placeholder="No spotlight job"
+                    ) }}
                 </div>
 
                 <a class="btn-job-link" href="#" target="_blank" rel="noopener">Job link</a>

--- a/event/Cargo.toml
+++ b/event/Cargo.toml
@@ -16,3 +16,5 @@ applicant = { path = "../applicant" }
 chrono = { workspace = true }
 job = { path = "../job" }
 shared = { path = "../shared" }
+serde_with = { workspace = true, features = ["macros"] }
+serde_withs = { path = "../serde_withs" }

--- a/event/migrations/002_seed_event.surql
+++ b/event/migrations/002_seed_event.surql
@@ -4,5 +4,5 @@ CREATE event CONTENT {
     status: 'Scheduled',
     start_date: '2024-01-01',
     end_date: '2024-01-01',
-    spotlight_job_id: job:rust_dev
+    job: job:rust_dev
 };

--- a/event/src/handlers.rs
+++ b/event/src/handlers.rs
@@ -1,23 +1,10 @@
 use std::sync::Arc;
-use axum::{Form, Json as AxumJson, extract::{State, Path}, response::{Html, IntoResponse}, http::StatusCode};
+use axum::{extract::{Path, State}, response::{Html, IntoResponse}, Form, Json as AxumJson, http::StatusCode};
 use applicant::AppState;
-use crate::models::{Event, EventStatus};
-use job::models::Job;
-use serde_json::{json, Value as Json};
-use shared::{internal_error, IdToString};
-use surrealdb::sql::Thing;
-use chrono::NaiveDate;
+use crate::models::Event;
+use serde_json::Value as Json;
+use shared::internal_error;
 
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct EventForm {
-    title: String,
-    description: String,
-    status: EventStatus,
-    start_date: NaiveDate,
-    end_date: NaiveDate,
-    spotlight_job_id: Option<String>,
-}
 
 pub async fn show_form(State(state): State<Arc<AppState>>) -> Result<Html<String>, (StatusCode, String)> {
 
@@ -37,24 +24,11 @@ pub async fn show_form(State(state): State<Arc<AppState>>) -> Result<Html<String
 
 pub(crate) async fn submit_form(
     State(state): State<Arc<AppState>>,
-    Form(form): Form<EventForm>,
+    Form(event): Form<Event>,
 ) -> impl IntoResponse {
-    let spotlight_job_id = match form.spotlight_job_id.as_deref() {
-        Some("") | None => None,
-        Some(s) => Some(
-            s.parse::<Thing>()
-                .expect("frontend <select> always sends valid job:<id>")
-        ),
-    };
-
     let new_event = Event {
         id: None,
-        title: form.title,
-        description: form.description,
-        status: form.status,
-        start_date: form.start_date,
-        end_date: form.end_date,
-        spotlight_job_id,
+        ..event
     };
 
     match new_event.create(&state.db).await {

--- a/event/src/handlers.rs
+++ b/event/src/handlers.rs
@@ -10,7 +10,7 @@ pub async fn show_form(State(state): State<Arc<AppState>>) -> Result<Html<String
 
     let select_opts: Vec<Json> = state
         .db
-        .query("SELECT record::id(id) AS value, title as title FROM job;")
+        .query("SELECT string::concat('job:', record::id(id)) AS value, title as title FROM job;")
         .await
         .map_err(internal_error)?
         .take::<Vec<Json>>(0)

--- a/event/src/models.rs
+++ b/event/src/models.rs
@@ -5,10 +5,11 @@ use serde_withs::ThingString;
 use surrealdb::{Surreal, engine::remote::ws::Client as WsClient, sql::Thing};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum EventStatus {
-    Pending,
+    Pending, 
     Scheduled,
+    Lobby,
     Live,
     Ended,
     Archived,
@@ -30,6 +31,7 @@ pub struct Event {
 
 impl Event {
     pub async fn create(self, db: &Surreal<WsClient>) -> surrealdb::Result<Self> {
+        println!("Creating event: {:?}", self);
         let created: Option<Self> = db.create("event").content(self).await?;
         Ok(created.expect("create returned none"))
     }

--- a/event/src/models.rs
+++ b/event/src/models.rs
@@ -1,5 +1,7 @@
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, FromInto};
+use serde_withs::ThingString;
 use surrealdb::{Surreal, engine::remote::ws::Client as WsClient, sql::Thing};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -12,6 +14,7 @@ pub enum EventStatus {
     Archived,
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
@@ -21,7 +24,8 @@ pub struct Event {
     pub status: EventStatus,
     pub start_date: NaiveDate,
     pub end_date: NaiveDate,
-    pub spotlight_job_id: Option<Thing>,
+    #[serde_as(as = "Option<FromInto<ThingString>>")]
+    pub job: Option<Thing>,
 }
 
 impl Event {

--- a/event/templates/event_form.html
+++ b/event/templates/event_form.html
@@ -23,7 +23,7 @@
             {{ forms::text_input(name="startDate", label="Start Date", type="date") }}
             {{ forms::text_input(name="endDate", label="End Date", type="date") }}
             {{ forms::select_input_ref(
-                 name        = "spotlightJobId",
+                 name        = "job",
                  label       = "Spotlight Job",
                  options     = job_options,
                  placeholder = "No spotlight job"

--- a/event/templates/event_form.html
+++ b/event/templates/event_form.html
@@ -17,7 +17,7 @@
             {{ forms::select_input(
                 name="status",
                 label="Status",
-                options=["scheduled", "lobby", "live", "ended", "archived"],
+                options=["pending", "scheduled", "lobby", "live", "ended", "archived"],
                 placeholder="Select a status"
             ) }}
             {{ forms::text_input(name="startDate", label="Start Date", type="date") }}

--- a/serde_withs/Cargo.toml
+++ b/serde_withs/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "serde_withs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { workspace = true }
+serde_with = { workspace = true }
+surrealdb = { workspace = true }
+

--- a/serde_withs/src/lib.rs
+++ b/serde_withs/src/lib.rs
@@ -1,0 +1,32 @@
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use surrealdb::sql::Thing;
+use std::{fmt, str::FromStr};
+
+#[derive(Clone, Debug, SerializeDisplay, DeserializeFromStr)]
+pub struct ThingString(pub Thing);
+
+impl fmt::Display for ThingString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for ThingString {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Thing::from_str(s).map(Self).map_err(|_| String::from("invalid Thing"))
+    }
+}
+
+impl From<Thing> for ThingString {
+    fn from(t: Thing) -> Self {
+        Self(t)
+    }
+}
+
+impl From<ThingString> for Thing {
+    fn from(w: ThingString) -> Self {
+        w.0
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce new `serde_withs` crate with `ThingString` converter
- parse event `job` using `ThingString` via `serde_with`
- drop DTO struct from event handler
- adjust event form input name and seed data
- document new `job` link field in vote data model

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: clippy missing)*
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6854e9500ea4832c8f5eca940ab6a6fe