### PR TITLE
Add Docker setup for website and SurrealDB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM rust:latest
 
 WORKDIR /app
 
-# Install cargo-watch for automatic rebuilding
+# Install cargo-watch for automatic rebuilding and SurrealDB CLI
 RUN cargo install cargo-watch
+RUN apt-get update && apt-get install -y curl
+RUN curl -sSf https://install.surrealdb.com | sh
 
 COPY . .
 
+# Make scripts executable
+RUN chmod +x run_all_migrations.sh start.sh
+
 EXPOSE 6969 3000 8000
 
-CMD ["cargo", "watch", "-x", "run --package website"]
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:latest
+
+WORKDIR /app
+
+# Install cargo-watch for automatic rebuilding
+RUN cargo install cargo-watch
+
+COPY . .
+
+EXPOSE 6969 3000 8000
+
+CMD ["cargo", "watch", "-x", "run --package website"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Your app will be running on: [http://localhost:6969](http://localhost:6969)
 | Database    | 8000         |
 
 
+## Docker
+
+Run the application and database using Docker:
+
+```bash
+docker compose up
+```
+
+This starts two containers:
+
+- **SurrealDb** on port `8000`
+- **Website** on ports `6969` and `3000`
+
+
 A CRM-like platform to form a battalion of cracked engineers and designers. 
 
 ### Design

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker compose up
 This starts two containers:
 
 - **SurrealDb** on port `8000`
-- **Website** on ports `6969` and `3000`
+- **Website** on ports `6969` and `3000`, running migrations on startup
 
 
 A CRM-like platform to form a battalion of cracked engineers and designers. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   website:
     container_name: Website
     build: .
-    command: cargo watch -x 'run --package website'
+    command: bash -c "chmod +x run_all_migrations.sh && ./run_all_migrations.sh && cargo watch -x 'run --package website'"
     environment:
       SURREALDB_URL: surrealdb:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+name: Battalion
+services:
+  surrealdb:
+    container_name: SurrealDb
+    image: surrealdb/surrealdb:latest
+    command: start --bind 0.0.0.0:8000 --user root --pass root memory
+    ports:
+      - "8000:8000"
+  website:
+    container_name: Website
+    build: .
+    command: cargo watch -x 'run --package website'
+    environment:
+      SURREALDB_URL: surrealdb:8000
+    depends_on:
+      - surrealdb
+    ports:
+      - "6969:6969"
+      - "3000:3000"

--- a/run_all_migrations.sh
+++ b/run_all_migrations.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # List of module directories
+DB_URL=${SURREALDB_URL:-127.0.0.1:8000}
+
 # MODULES=("job" "event" "applicant" "vote")
 MODULES=("job" "event" "applicant")
 
@@ -10,7 +12,7 @@ for module in "${MODULES[@]}"; do
 
   for file in migrations/*.surql; do
     echo "🚀 Running migration: $module/$file"
-    surreal sql --conn http://127.0.0.1:8000 \
+    surreal sql --conn http://$DB_URL \
                 --user root \
                 --pass root \
                 --ns test \

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "🚀 Starting Battalion application..."
+
+# Run database migrations
+echo "📊 Running database migrations..."
+./run_all_migrations.sh
+
+# Start the website
+echo "🌐 Starting website..."
+cargo watch -x "run --package website"


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose with Website and SurrealDb services
- allow website to read SurrealDB URL from env and bind on all interfaces
- document Docker usage

## Testing
- `cargo fmt --all -- --check` *(fails: left behind trailing whitespace)*
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: get-first lint in existing code)*
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6895399132c88326bf4d4640f814eab4