### PR TITLE
Ensure consistent nightly toolchain and clean handlers

### DIFF
--- a/home/src/handlers.rs
+++ b/home/src/handlers.rs
@@ -20,9 +20,9 @@ pub async fn index(State(state): State<Arc<AppState>>) -> Result<Html<String>, (
         .db
         .query("SELECT string::concat('event:', record::id(id)) AS value, title as title, startDate AS startDate FROM event;")
         .await
-        .map_err(internal_error)?   
-        .take(0)                    
-        .map_err(internal_error)?; 
+        .map_err(internal_error)?
+        .take(0)
+        .map_err(internal_error)?;
 
     let job_count: Vec<Value> = state
         .db
@@ -32,7 +32,7 @@ pub async fn index(State(state): State<Arc<AppState>>) -> Result<Html<String>, (
         .take(0)
         .map_err(internal_error)?;
 
-    let has_jobs = if let Some(Value::Object(count_obj)) = job_count.get(0) {
+    let has_jobs = if let Some(Value::Object(count_obj)) = job_count.first() {
         if let Some(Value::Number(count)) = count_obj.get("count") {
             count.as_u64().unwrap_or(0) > 0
         } else {
@@ -48,7 +48,7 @@ pub async fn index(State(state): State<Arc<AppState>>) -> Result<Html<String>, (
     ctx.insert("event_options", &select_opts);
     ctx.insert("has_jobs", &has_jobs);
 
-    if let Some(Value::Object(first)) = select_opts.get(0) {
+    if let Some(Value::Object(first)) = select_opts.first() {
         if let Some(Value::String(start_date)) = first.get("startDate") {
             if let Ok(datetime) = start_date.parse::<DateTime<Utc>>() {
                 // Get Unix timestamp in seconds

--- a/queue/src/handlers.rs
+++ b/queue/src/handlers.rs
@@ -11,13 +11,13 @@ pub async fn index(State(state): State<Arc<AppState>>) -> Result<Html<String>, (
         .db
         .query("SELECT string::concat('event:', record::id(id)) AS value, title as title, startDate AS startDate FROM event;")
         .await
-        .map_err(internal_error)?   
-        .take(0)                    
-        .map_err(internal_error)?; 
+        .map_err(internal_error)?
+        .take(0)
+        .map_err(internal_error)?;
 
     let mut ctx = Context::new();
-    
-    if let Some(Value::Object(first)) = select_opts.get(0) {
+
+    if let Some(Value::Object(first)) = select_opts.first() {
         if let Some(Value::String(start_date)) = first.get("startDate") {
             if let Ok(datetime) = start_date.parse::<DateTime<Utc>>() {
                 // Get Unix timestamp in seconds

--- a/review/src/handlers.rs
+++ b/review/src/handlers.rs
@@ -57,11 +57,13 @@ pub(crate) async fn show_page(
         .map_err(internal_error)?;
 
     // Get the applicant ID to filter votes by - either from params or use first applicant
-    let target_applicant_id = params.applicant_id.as_ref()
-        .map(|id| id.clone())
+    let target_applicant_id = params
+        .applicant_id
+        .clone()
         .or_else(|| {
             // If no applicant_id in params, get the first applicant's ID
-            select_applicants.get(0)
+            select_applicants
+                .first()
                 .and_then(|obj| obj.get("value"))
                 .and_then(|val| val.as_str())
                 .map(|s| s.to_string())
@@ -115,21 +117,22 @@ pub(crate) async fn show_page(
     ctx.insert("scoreboard", &scoreboard);
 
     let first_event = select_opts
-        .get(0)
+        .first()
         .and_then(|obj| obj.get("value"))
         .and_then(|val| val.as_str())
         .map(|s| s.to_string());
 
     let first_job = select_jobs
-        .get(0)
+        .first()
         .and_then(|obj| obj.get("value"))
         .and_then(|val| val.as_str())
         .map(|s| s.to_string());
 
-    let first_application = select_applicants.get(0)
-    .and_then(|obj| obj.get("value"))
-    .and_then(|val| val.as_str())
-    .map(|s| s.to_string());
+    let first_application = select_applicants
+        .first()
+        .and_then(|obj| obj.get("value"))
+        .and_then(|val| val.as_str())
+        .map(|s| s.to_string());
 
     let session_id = generate_session_id(first_application.as_deref(), first_event.as_deref(), first_job.as_deref());
     eprintln!("Generated session ID: {:?}", session_id);
@@ -142,7 +145,7 @@ pub(crate) async fn show_page(
         // Use the full applicant_id as provided (should be "apply:xxxxx")
         let query = format!("SELECT * FROM apply WHERE id = {}", applicant_id);
         eprintln!("Querying for applicant with ID: {}", applicant_id);
-        
+
         state.db
             .query(&query)
             .await
@@ -188,11 +191,11 @@ pub(crate) async fn show_page(
     }
 
     let total_count = total_apply_records
-        .get(0)
+        .first()
         .and_then(|obj| obj.get("count"))
         .and_then(|val| val.as_u64())
         .unwrap_or(0);
-    
+
     ctx.insert("applicant", &first_applicant);
     ctx.insert("yay_count", &yay_count);
     ctx.insert("nay_count", &nay_count);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "clippy"]
+

--- a/start.sh
+++ b/start.sh
@@ -9,3 +9,4 @@ echo "📊 Running database migrations..."
 # Start the website
 echo "🌐 Starting website..."
 cargo watch -x "run --package website"
+

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -2,21 +2,13 @@ use axum::Router;
 use std::path::Path;
 use std::sync::Arc;
 // use axum::routing::get;
-use applicant::{self, AppState};
-use event;
-use home;
-use job;
-use leaderboard;
-use queue;
-use review;
-use shared;
-use surrealdb::Surreal;
+use applicant::AppState;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
+use surrealdb::Surreal;
 use tera::Tera;
 use tokio::sync::broadcast;
 use tower_http::services::ServeDir;
-use vote;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Summary
- Pin repository to the nightly Rust toolchain for consistent builds
- Replace Vec indexing with `first()` and streamline imports
- Fix startup script line ending

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6897f2242d408326b98495c328e14e49